### PR TITLE
handle cannot read property of undefined error

### DIFF
--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -12,7 +12,7 @@ class Link extends React.Component {
       push: PropTypes.func.isRequired,
       replace: PropTypes.func.isRequired,
       createHref: PropTypes.func.isRequired
-    }).isRequired
+    })
   }
 
   static propTypes = {
@@ -54,9 +54,8 @@ class Link extends React.Component {
 
   render() {
     const { replace, to, ...props } = this.props // eslint-disable-line no-unused-vars
-
-    const href = this.context.history.createHref(
-      typeof to === 'string' ? { pathname: to } : to
+    var href = this.context.history ? this.context.history.createHref(typeof to === 'string' ? { pathname: to } : to) : undefined;
+    
     )
 
     return <a {...props} onClick={this.handleClick} href={href}/>


### PR DESCRIPTION
Handling a warning and an error
1. Warning: Failed context type: The context `history` is marked as required in `Link`, but its value is `undefined`.
2. TypeError: Cannot read property 'createHref' of undefined
Refer to https://github.com/ReactTraining/react-router/issues/4660